### PR TITLE
feat: add NodejsFunction construct and create common alarm infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 # AWS Constructs
+
 This repo contains thin wrappers for CDK constructs to ensure a consistent standard is applied to generated cloud resources and to avoid repetitive boilerplate code.
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Preamble
+
 There are a few conventions when using this library to be aware of.
 
-1. Constructs expect the CDK [context values](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#w53aac33b7c33c11) `ENVIRONMENT` and `CUSTOMER` to be declared via the CLI:
-   2. `ENVIRONMENT` - eg: `dev`, `stage`, `prod` etc but you can use whatever you want
-   3. `CUSTOMER` - a string representing the end client of your software. This library is built with a SaaS mindset, where each customer can have their own configuration. If this doesn't apply to you we recommend simply using your own business name.
+1. Constructs expect the CDK [context values](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#w53aac33b7c33c11) `ENVIRONMENT` and `CUSTOMER` to be declared via the CLI: 2. `ENVIRONMENT` - eg: `dev`, `stage`, `prod` etc but you can use whatever you want 3. `CUSTOMER` - a string representing the end client of your software. This library is built with a SaaS mindset, where each customer can have their own configuration. If this doesn't apply to you we recommend simply using your own business name.
 2. Your `cdk.context.json` [file](https://docs.aws.amazon.com/cdk/v2/guide/context.html) should adopt a structure of:
 
 ```json
 {
-  "cuckoo": {               // <--- customer(s)
-    "prod": {               // <--- environment(s)
-      "logLevel": "debug"   // <--- option(s)
+  "cuckoo": {
+    // <--- customer(s)
+    "prod": {
+      // <--- environment(s)
+      "logLevel": "debug" // <--- option(s)
     }
   }
 }
@@ -76,7 +80,12 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as AWSConstructs from "@cuckoointernet/aws-constructs";
 
 class ExampleFunction extends AWSConstructs.lambda.Function {
-  constructor(scope: Construct, id: string, props: lambda.FunctionProps, customProps?: CustomLambdaProps) {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: lambda.FunctionProps,
+    customProps?: CustomLambdaProps
+  ) {
     super(
       scope,
       ExampleFunction.name,
@@ -89,6 +98,41 @@ class ExampleFunction extends AWSConstructs.lambda.Function {
       },
       {
         // Custom AWS Construct options
+      }
+    );
+  }
+}
+```
+
+## `lambda.NodejsFunction`
+
+As well as the [usual defaults](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html#construct-props), this construct will additionally configure the same properties as [`lambda.Function`](#lambda.function). This construct is specifically aimed at taking advantage of the same great defaults, but giving the option to use [`esbuild`](https://esbuild.github.io) to build Lambda source code.
+
+### Usage
+
+```typescript
+import * as lambdaNode from "aws-cdk-lib/aws-lambda-nodejs";
+import * as CuckooConstructs from "@cuckoointernet/cuckoo-constructs";
+
+class ExampleFunction extends CuckooConstructs.lambda.NodejsFunction {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: lambdaNode.NodejsFunctionProps,
+    customProps?: CustomLambdaProps
+  ) {
+    super(
+      scope,
+      ExampleFunction.name,
+      {
+        entry: "src/lambda/node-mock-handler.ts",
+        handler: "handleTheStuff",
+
+        // To override the default behaviour of this construct you can supply your own props here...
+        // See: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Function.html#construct-props
+      },
+      {
+        // Custom Cuckoo Construct options
       }
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/get-value": "3.0.3",
         "@types/jest": "29.5.4",
         "@types/node": "20.6.0",
+        "esbuild": "^0.19.3",
         "husky": "8.0.3",
         "jest": "29.7.0",
         "lint-staged": "14.0.1",
@@ -617,6 +618,358 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.3.tgz",
+      "integrity": "sha512-Lemgw4io4VZl9GHJmjiBGzQ7ONXRfRPHcUEerndjwiSkbxzrpq0Uggku5MxxrXdwJ+pTj1qyw4jwTu7hkPsgIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.3.tgz",
+      "integrity": "sha512-w+Akc0vv5leog550kjJV9Ru+MXMR2VuMrui3C61mnysim0gkFCPOUTAfzTP0qX+HpN9Syu3YA3p1hf3EPqObRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.3.tgz",
+      "integrity": "sha512-FKQJKkK5MXcBHoNZMDNUAg1+WcZlV/cuXrWCoGF/TvdRiYS4znA0m5Il5idUwfxrE20bG/vU1Cr5e1AD6IEIjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.3.tgz",
+      "integrity": "sha512-kw7e3FXU+VsJSSSl2nMKvACYlwtvZB8RUIeVShIEY6PVnuZ3c9+L9lWB2nWeeKWNNYDdtL19foCQ0ZyUL7nqGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.3.tgz",
+      "integrity": "sha512-tPfZiwF9rO0jW6Jh9ipi58N5ZLoSjdxXeSrAYypy4psA2Yl1dAMhM71KxVfmjZhJmxRjSnb29YlRXXhh3GqzYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.3.tgz",
+      "integrity": "sha512-ERDyjOgYeKe0Vrlr1iLrqTByB026YLPzTytDTz1DRCYM+JI92Dw2dbpRHYmdqn6VBnQ9Bor6J8ZlNwdZdxjlSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.3.tgz",
+      "integrity": "sha512-nXesBZ2Ad1qL+Rm3crN7NmEVJ5uvfLFPLJev3x1j3feCQXfAhoYrojC681RhpdOph8NsvKBBwpYZHR7W0ifTTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.3.tgz",
+      "integrity": "sha512-zr48Cg/8zkzZCzDHNxXO/89bf9e+r4HtzNUPoz4GmgAkF1gFAFmfgOdCbR8zMbzFDGb1FqBBhdXUpcTQRYS1cQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.3.tgz",
+      "integrity": "sha512-qXvYKmXj8GcJgWq3aGvxL/JG1ZM3UR272SdPU4QSTzD0eymrM7leiZH77pvY3UetCy0k1xuXZ+VPvoJNdtrsWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.3.tgz",
+      "integrity": "sha512-7XlCKCA0nWcbvYpusARWkFjRQNWNGlt45S+Q18UeS///K6Aw8bB2FKYe9mhVWy/XLShvCweOLZPrnMswIaDXQA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.3.tgz",
+      "integrity": "sha512-qGTgjweER5xqweiWtUIDl9OKz338EQqCwbS9c2Bh5jgEH19xQ1yhgGPNesugmDFq+UUSDtWgZ264st26b3de8A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.3.tgz",
+      "integrity": "sha512-gy1bFskwEyxVMFRNYSvBauDIWNggD6pyxUksc0MV9UOBD138dKTzr8XnM2R4mBsHwVzeuIH8X5JhmNs2Pzrx+A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.3.tgz",
+      "integrity": "sha512-UrYLFu62x1MmmIe85rpR3qou92wB9lEXluwMB/STDzPF9k8mi/9UvNsG07Tt9AqwPQXluMQ6bZbTzYt01+Ue5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.3.tgz",
+      "integrity": "sha512-9E73TfyMCbE+1AwFOg3glnzZ5fBAFK4aawssvuMgCRqCYzE0ylVxxzjEfut8xjmKkR320BEoMui4o/t9KA96gA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.3.tgz",
+      "integrity": "sha512-LlmsbuBdm1/D66TJ3HW6URY8wO6IlYHf+ChOUz8SUAjVTuaisfuwCOAgcxo3Zsu3BZGxmI7yt//yGOxV+lHcEA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.3.tgz",
+      "integrity": "sha512-ogV0+GwEmvwg/8ZbsyfkYGaLACBQWDvO0Kkh8LKBGKj9Ru8VM39zssrnu9Sxn1wbapA2qNS6BiLdwJZGouyCwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-o1jLNe4uzQv2DKXMlmEzf66Wd8MoIhLNO2nlQBHLtWyh2MitDG7sMpfCO3NTcoTMuqHjfufgUQDFRI5C+xsXQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-AZJCnr5CZgZOdhouLcfRdnk9Zv6HbaBxjcyhq0StNcvAdVZJSKIdOiPB9az2zc06ywl0ePYJz60CjdKsQacp5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.3.tgz",
+      "integrity": "sha512-Acsujgeqg9InR4glTRvLKGZ+1HMtDm94ehTIHKhJjFpgVzZG9/pIcWW/HA/DoMfEyXmANLDuDZ2sNrWcjq1lxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.3.tgz",
+      "integrity": "sha512-FSrAfjVVy7TifFgYgliiJOyYynhQmqgPj15pzLyJk8BUsnlWNwP/IAy6GAiB1LqtoivowRgidZsfpoYLZH586A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.3.tgz",
+      "integrity": "sha512-xTScXYi12xLOWZ/sc5RBmMN99BcXp/eEf7scUC0oeiRoiT5Vvo9AycuqCp+xdpDyAU+LkrCqEpUS9fCSZF8J3Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.3.tgz",
+      "integrity": "sha512-FbUN+0ZRXsypPyWE2IwIkVjDkDnJoMJARWOcFZn4KPPli+QnKqF0z1anvfaYe3ev5HFCpRDLLBDHyOALLppWHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3623,6 +3976,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.3.tgz",
+      "integrity": "sha512-UlJ1qUUA2jL2nNib1JTSkifQTcYTroFqRjwCFW4QYEKEsixXD5Tik9xML7zh2gTxkYTBKGHNH9y7txMwVyPbjw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.19.3",
+        "@esbuild/android-arm64": "0.19.3",
+        "@esbuild/android-x64": "0.19.3",
+        "@esbuild/darwin-arm64": "0.19.3",
+        "@esbuild/darwin-x64": "0.19.3",
+        "@esbuild/freebsd-arm64": "0.19.3",
+        "@esbuild/freebsd-x64": "0.19.3",
+        "@esbuild/linux-arm": "0.19.3",
+        "@esbuild/linux-arm64": "0.19.3",
+        "@esbuild/linux-ia32": "0.19.3",
+        "@esbuild/linux-loong64": "0.19.3",
+        "@esbuild/linux-mips64el": "0.19.3",
+        "@esbuild/linux-ppc64": "0.19.3",
+        "@esbuild/linux-riscv64": "0.19.3",
+        "@esbuild/linux-s390x": "0.19.3",
+        "@esbuild/linux-x64": "0.19.3",
+        "@esbuild/netbsd-x64": "0.19.3",
+        "@esbuild/openbsd-x64": "0.19.3",
+        "@esbuild/sunos-x64": "0.19.3",
+        "@esbuild/win32-arm64": "0.19.3",
+        "@esbuild/win32-ia32": "0.19.3",
+        "@esbuild/win32-x64": "0.19.3"
       }
     },
     "node_modules/escalade": {
@@ -9857,6 +10247,160 @@
         }
       }
     },
+    "@esbuild/android-arm": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.3.tgz",
+      "integrity": "sha512-Lemgw4io4VZl9GHJmjiBGzQ7ONXRfRPHcUEerndjwiSkbxzrpq0Uggku5MxxrXdwJ+pTj1qyw4jwTu7hkPsgIA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.3.tgz",
+      "integrity": "sha512-w+Akc0vv5leog550kjJV9Ru+MXMR2VuMrui3C61mnysim0gkFCPOUTAfzTP0qX+HpN9Syu3YA3p1hf3EPqObRw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.3.tgz",
+      "integrity": "sha512-FKQJKkK5MXcBHoNZMDNUAg1+WcZlV/cuXrWCoGF/TvdRiYS4znA0m5Il5idUwfxrE20bG/vU1Cr5e1AD6IEIjQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.3.tgz",
+      "integrity": "sha512-kw7e3FXU+VsJSSSl2nMKvACYlwtvZB8RUIeVShIEY6PVnuZ3c9+L9lWB2nWeeKWNNYDdtL19foCQ0ZyUL7nqGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.3.tgz",
+      "integrity": "sha512-tPfZiwF9rO0jW6Jh9ipi58N5ZLoSjdxXeSrAYypy4psA2Yl1dAMhM71KxVfmjZhJmxRjSnb29YlRXXhh3GqzYw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.3.tgz",
+      "integrity": "sha512-ERDyjOgYeKe0Vrlr1iLrqTByB026YLPzTytDTz1DRCYM+JI92Dw2dbpRHYmdqn6VBnQ9Bor6J8ZlNwdZdxjlSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.3.tgz",
+      "integrity": "sha512-nXesBZ2Ad1qL+Rm3crN7NmEVJ5uvfLFPLJev3x1j3feCQXfAhoYrojC681RhpdOph8NsvKBBwpYZHR7W0ifTTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.3.tgz",
+      "integrity": "sha512-zr48Cg/8zkzZCzDHNxXO/89bf9e+r4HtzNUPoz4GmgAkF1gFAFmfgOdCbR8zMbzFDGb1FqBBhdXUpcTQRYS1cQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.3.tgz",
+      "integrity": "sha512-qXvYKmXj8GcJgWq3aGvxL/JG1ZM3UR272SdPU4QSTzD0eymrM7leiZH77pvY3UetCy0k1xuXZ+VPvoJNdtrsWQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.3.tgz",
+      "integrity": "sha512-7XlCKCA0nWcbvYpusARWkFjRQNWNGlt45S+Q18UeS///K6Aw8bB2FKYe9mhVWy/XLShvCweOLZPrnMswIaDXQA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.3.tgz",
+      "integrity": "sha512-qGTgjweER5xqweiWtUIDl9OKz338EQqCwbS9c2Bh5jgEH19xQ1yhgGPNesugmDFq+UUSDtWgZ264st26b3de8A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.3.tgz",
+      "integrity": "sha512-gy1bFskwEyxVMFRNYSvBauDIWNggD6pyxUksc0MV9UOBD138dKTzr8XnM2R4mBsHwVzeuIH8X5JhmNs2Pzrx+A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.3.tgz",
+      "integrity": "sha512-UrYLFu62x1MmmIe85rpR3qou92wB9lEXluwMB/STDzPF9k8mi/9UvNsG07Tt9AqwPQXluMQ6bZbTzYt01+Ue5g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.3.tgz",
+      "integrity": "sha512-9E73TfyMCbE+1AwFOg3glnzZ5fBAFK4aawssvuMgCRqCYzE0ylVxxzjEfut8xjmKkR320BEoMui4o/t9KA96gA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.3.tgz",
+      "integrity": "sha512-LlmsbuBdm1/D66TJ3HW6URY8wO6IlYHf+ChOUz8SUAjVTuaisfuwCOAgcxo3Zsu3BZGxmI7yt//yGOxV+lHcEA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.3.tgz",
+      "integrity": "sha512-ogV0+GwEmvwg/8ZbsyfkYGaLACBQWDvO0Kkh8LKBGKj9Ru8VM39zssrnu9Sxn1wbapA2qNS6BiLdwJZGouyCwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-o1jLNe4uzQv2DKXMlmEzf66Wd8MoIhLNO2nlQBHLtWyh2MitDG7sMpfCO3NTcoTMuqHjfufgUQDFRI5C+xsXQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-AZJCnr5CZgZOdhouLcfRdnk9Zv6HbaBxjcyhq0StNcvAdVZJSKIdOiPB9az2zc06ywl0ePYJz60CjdKsQacp5Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.3.tgz",
+      "integrity": "sha512-Acsujgeqg9InR4glTRvLKGZ+1HMtDm94ehTIHKhJjFpgVzZG9/pIcWW/HA/DoMfEyXmANLDuDZ2sNrWcjq1lxw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.3.tgz",
+      "integrity": "sha512-FSrAfjVVy7TifFgYgliiJOyYynhQmqgPj15pzLyJk8BUsnlWNwP/IAy6GAiB1LqtoivowRgidZsfpoYLZH586A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.3.tgz",
+      "integrity": "sha512-xTScXYi12xLOWZ/sc5RBmMN99BcXp/eEf7scUC0oeiRoiT5Vvo9AycuqCp+xdpDyAU+LkrCqEpUS9fCSZF8J3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.3.tgz",
+      "integrity": "sha512-FbUN+0ZRXsypPyWE2IwIkVjDkDnJoMJARWOcFZn4KPPli+QnKqF0z1anvfaYe3ev5HFCpRDLLBDHyOALLppWHw==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -12029,6 +12573,36 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.3.tgz",
+      "integrity": "sha512-UlJ1qUUA2jL2nNib1JTSkifQTcYTroFqRjwCFW4QYEKEsixXD5Tik9xML7zh2gTxkYTBKGHNH9y7txMwVyPbjw==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.19.3",
+        "@esbuild/android-arm64": "0.19.3",
+        "@esbuild/android-x64": "0.19.3",
+        "@esbuild/darwin-arm64": "0.19.3",
+        "@esbuild/darwin-x64": "0.19.3",
+        "@esbuild/freebsd-arm64": "0.19.3",
+        "@esbuild/freebsd-x64": "0.19.3",
+        "@esbuild/linux-arm": "0.19.3",
+        "@esbuild/linux-arm64": "0.19.3",
+        "@esbuild/linux-ia32": "0.19.3",
+        "@esbuild/linux-loong64": "0.19.3",
+        "@esbuild/linux-mips64el": "0.19.3",
+        "@esbuild/linux-ppc64": "0.19.3",
+        "@esbuild/linux-riscv64": "0.19.3",
+        "@esbuild/linux-s390x": "0.19.3",
+        "@esbuild/linux-x64": "0.19.3",
+        "@esbuild/netbsd-x64": "0.19.3",
+        "@esbuild/openbsd-x64": "0.19.3",
+        "@esbuild/sunos-x64": "0.19.3",
+        "@esbuild/win32-arm64": "0.19.3",
+        "@esbuild/win32-ia32": "0.19.3",
+        "@esbuild/win32-x64": "0.19.3"
       }
     },
     "escalade": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.51.0",
-    "constructs": "^10.2.70"
+    "constructs": "^10.2.70",
+    "esbuild": "^0.19.3"
   },
   "devDependencies": {
     "@tsconfig/node18": "18.2.2",
     "@types/get-value": "3.0.3",
     "@types/jest": "29.5.4",
     "@types/node": "20.6.0",
+    "esbuild": "^0.19.3",
     "husky": "8.0.3",
     "jest": "29.7.0",
     "lint-staged": "14.0.1",

--- a/src/lambda/common.ts
+++ b/src/lambda/common.ts
@@ -1,0 +1,174 @@
+import * as cdk from "aws-cdk-lib";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import type * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as cw_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import { getContextByPath } from "../utils";
+
+type CustomAlarmOptions = Omit<
+  cloudwatch.CreateAlarmOptions,
+  "alarmDescription"
+>;
+
+export type CustomLambdaProps = {
+  errorsAlarmOptions?: CustomAlarmOptions;
+  throttlesAlarmOptions?: CustomAlarmOptions;
+  durationAlarmOptions?: CustomAlarmOptions;
+  memoryUtilizationAlarmOptions?: CustomAlarmOptions;
+  disableAlarmNotifications?: boolean;
+  ssmParameterPaths?: string[];
+};
+
+type AlarmOptions = {
+  lambdaFunction: lambda.Function;
+  id: string;
+  timeout: cdk.Duration;
+  insightsVersion: lambda.LambdaInsightsVersion | undefined;
+  customer: string;
+  environment: string;
+} & CustomLambdaProps;
+
+type Alarms = {
+  throttlesAlarm: cloudwatch.Alarm;
+  errorsAlarm: cloudwatch.Alarm;
+  durationAlarm: cloudwatch.Alarm;
+  memoryUtilizationAlarm: cloudwatch.Alarm | undefined;
+};
+
+export const createAlarms = ({
+  lambdaFunction,
+  id,
+  timeout,
+  insightsVersion,
+  customer,
+  environment,
+  errorsAlarmOptions,
+  durationAlarmOptions,
+  throttlesAlarmOptions,
+  memoryUtilizationAlarmOptions,
+  disableAlarmNotifications,
+}: AlarmOptions): Alarms => {
+  // Error Alarm
+  const defaultErrorAlarmOptions: cloudwatch.CreateAlarmOptions = {
+    alarmDescription: `Lambda errors reported by ${id}`,
+    threshold: 1,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  };
+
+  const errorsAlarm = lambdaFunction
+    .metricErrors({
+      statistic: "Maximum",
+    })
+    .createAlarm(lambdaFunction, "Errors", {
+      ...defaultErrorAlarmOptions,
+      ...errorsAlarmOptions,
+    });
+
+  // Duration alarm
+  const defaultDurationAlarmOptions: cloudwatch.CreateAlarmOptions = {
+    alarmDescription: `Lambda invocations close to reaching max timeout for ${id}`,
+    threshold: timeout.toMilliseconds() * 0.75,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  };
+
+  const durationAlarm = lambdaFunction
+    .metricDuration({
+      statistic: "Maximum",
+    })
+    .createAlarm(lambdaFunction, "Duration", {
+      ...defaultDurationAlarmOptions,
+      ...durationAlarmOptions,
+    });
+
+  // Throttles alarm
+  const defaultThrottlesAlarmOptions: cloudwatch.CreateAlarmOptions = {
+    alarmDescription: `Lambda invocations consistently being throttled for ${id}`,
+    threshold: 1,
+    evaluationPeriods: 6,
+    datapointsToAlarm: 4,
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  };
+
+  const throttlesAlarm = lambdaFunction
+    .metricThrottles({
+      statistic: "Maximum",
+    })
+    .createAlarm(lambdaFunction, "Throttles", {
+      ...defaultThrottlesAlarmOptions,
+      ...throttlesAlarmOptions,
+    });
+
+  // Memory utilization alarm
+  let memoryUtilizationAlarm: cloudwatch.Alarm | undefined;
+  if (insightsVersion) {
+    const defaultMemoryUtilizationAlarmOptions: cloudwatch.CreateAlarmOptions =
+      {
+        alarmDescription: `Lambda memory utilization high for ${id}`,
+        threshold: 75,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      };
+
+    memoryUtilizationAlarm = new cloudwatch.Metric({
+      namespace: "LambdaInsights",
+      metricName: "memory_utilization",
+      statistic: "Maximum",
+      label: "Memory Utilization Percentage",
+      dimensionsMap: {
+        function_name: lambdaFunction.functionName,
+      },
+    })
+      .attachTo(lambdaFunction)
+      .createAlarm(lambdaFunction, "MemoryUtilization", {
+        ...defaultMemoryUtilizationAlarmOptions,
+        ...memoryUtilizationAlarmOptions,
+      });
+  }
+
+  const alarmNotificationsTopic = getContextByPath(
+    lambdaFunction,
+    `${customer}.${environment}.alarmNotificationsTopic`
+  ) as string | undefined;
+
+  if (alarmNotificationsTopic && !disableAlarmNotifications) {
+    const alarmTopicArn = cdk.Arn.format(
+      {
+        service: "sns",
+        resource: alarmNotificationsTopic,
+      },
+      cdk.Stack.of(lambdaFunction)
+    );
+
+    const alarmTopic = sns.Topic.fromTopicArn(
+      lambdaFunction,
+      "AlarmNotificationsTopic",
+      alarmTopicArn
+    );
+
+    errorsAlarm.addAlarmAction(new cw_actions.SnsAction(alarmTopic));
+    errorsAlarm.addOkAction(new cw_actions.SnsAction(alarmTopic));
+    durationAlarm.addAlarmAction(new cw_actions.SnsAction(alarmTopic));
+    durationAlarm.addOkAction(new cw_actions.SnsAction(alarmTopic));
+    throttlesAlarm.addAlarmAction(new cw_actions.SnsAction(alarmTopic));
+    throttlesAlarm.addOkAction(new cw_actions.SnsAction(alarmTopic));
+
+    if (memoryUtilizationAlarm) {
+      memoryUtilizationAlarm.addAlarmAction(
+        new cw_actions.SnsAction(alarmTopic)
+      );
+      memoryUtilizationAlarm.addOkAction(new cw_actions.SnsAction(alarmTopic));
+    }
+  }
+
+  return {
+    errorsAlarm,
+    durationAlarm,
+    throttlesAlarm,
+    memoryUtilizationAlarm,
+  };
+};

--- a/src/lambda/index.ts
+++ b/src/lambda/index.ts
@@ -1,1 +1,2 @@
 export * from "./function";
+export * from "./nodejs-function";

--- a/src/lambda/nodejs-function.test.ts
+++ b/src/lambda/nodejs-function.test.ts
@@ -1,0 +1,830 @@
+/* eslint-disable no-new, unicorn/prefer-module */
+import path from "path";
+import * as cdk from "aws-cdk-lib";
+import { type Construct } from "constructs";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { NodejsFunction } from "./nodejs-function";
+
+const context = {
+  ENVIRONMENT: "prod",
+  CUSTOMER: "cuckoo",
+  cuckoo: {
+    prod: {
+      alarmNotificationsTopic: "exampleSnsTopic",
+      logLevel: "debug",
+    },
+  },
+};
+
+describe("NodejsFunction", () => {
+  describe("description", () => {
+    it("should default to constructor ID and env", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Description: "Function-prod",
+      });
+    });
+
+    it("should be overridable via props", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            description: "unrelated",
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            runtime: lambda.Runtime.NODEJS_12_X,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Description: "unrelated",
+      });
+    });
+  });
+
+  describe("runtime", () => {
+    it("should default to Node 18", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Runtime: "nodejs18.x",
+      });
+    });
+
+    it("should be overridable via props", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            runtime: lambda.Runtime.NODEJS_12_X,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Runtime: "nodejs12.x",
+      });
+    });
+  });
+
+  describe("architecture", () => {
+    it("should default to arm64", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Architectures: ["arm64"],
+      });
+    });
+
+    it("should be overridable via props", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            architecture: lambda.Architecture.X86_64,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Architectures: ["x86_64"],
+      });
+    });
+  });
+
+  describe("logRetention", () => {
+    it("should default to six months", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("Custom::LogRetention", {
+        RetentionInDays: 180,
+      });
+    });
+
+    it("should be overridable via props", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            logRetention: RetentionDays.ONE_YEAR,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("Custom::LogRetention", {
+        RetentionInDays: 365,
+      });
+    });
+  });
+
+  describe("environment variables", () => {
+    it("should set ENVIRONMENT based on context value", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Environment: {
+          Variables: {
+            ENVIRONMENT: "prod",
+          },
+        },
+      });
+    });
+
+    it("should set LOG_LEVEL based on context value", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Environment: {
+          Variables: {
+            LOG_LEVEL: "debug",
+          },
+        },
+      });
+    });
+
+    it("should default LOG_LEVEL to 'debug' if no logLevel configured via context", () => {
+      const app = new cdk.App({
+        context: {
+          ENVIRONMENT: "prod",
+          CUSTOMER: "cuckoo",
+          cuckoo: {
+            prod: {
+              alarmNotificationsTopic: "exampleSnsTopic",
+              // Deliberately omit logLevel
+            },
+          },
+        },
+      });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        Environment: {
+          Variables: {
+            LOG_LEVEL: "debug",
+          },
+        },
+      });
+    });
+  });
+
+  describe("alarms", () => {
+    it("should configure an errors alarm", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        Statistic: "Maximum",
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 1,
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        Period: 300, // 5 mins
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("should configure a duration alarm", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Duration",
+        Statistic: "Maximum",
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 2250, // 75% of default 3 second timeout
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        Period: 300, // 5 mins
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("should configure a throttles alarm", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Throttles",
+        Statistic: "Maximum",
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 1,
+        EvaluationPeriods: 6,
+        DatapointsToAlarm: 4,
+        Period: 300, // 5 mins
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("should configure a memory utilization alarm if CloudWatch Lambda Insights is enabled", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "MyFunction", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_135_0,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: [
+          {
+            MetricStat: {
+              Stat: "Maximum",
+              Period: 300, // 5 mins
+              Metric: {
+                Namespace: "LambdaInsights",
+                MetricName: "memory_utilization",
+                Dimensions: [
+                  {
+                    Name: "function_name",
+                    Value: { Ref: Match.stringLikeRegexp("^MyFunction.*") },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 75,
+        EvaluationPeriods: 1,
+        DatapointsToAlarm: 1,
+        TreatMissingData: "notBreaching",
+      });
+    });
+
+    it("should not configure a memory utilization alarm if CloudWatch Lambda Insights is disabled", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "MyFunction", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            // Deliberately omit insightsVersion property
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.resourcePropertiesCountIs(
+        "AWS::CloudWatch::Alarm",
+        {
+          Metrics: Match.arrayWith([
+            Match.objectLike({
+              MetricStat: {
+                Metric: {
+                  Namespace: "LambdaInsights",
+                  MetricName: "memory_utilization",
+                },
+              },
+            }),
+          ]),
+        },
+        0
+      );
+    });
+
+    it("should override alarms if options are provided", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(
+            this,
+            "MyFunction",
+            {
+              entry: path.join(__dirname, "test/mock-handler.ts"),
+              insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_135_0,
+            },
+            {
+              errorsAlarmOptions: {
+                threshold: 2,
+                evaluationPeriods: 5,
+                datapointsToAlarm: 7,
+                treatMissingData: TreatMissingData.BREACHING,
+              },
+              durationAlarmOptions: {
+                threshold: cdk.Duration.seconds(3).toMilliseconds() * 0.4,
+                evaluationPeriods: 4,
+                datapointsToAlarm: 1,
+              },
+              memoryUtilizationAlarmOptions: {
+                threshold: 50,
+                evaluationPeriods: 6,
+                datapointsToAlarm: 2,
+              },
+            }
+          );
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        Statistic: "Maximum",
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 2,
+        EvaluationPeriods: 5,
+        DatapointsToAlarm: 7,
+        Period: 300, // 5 mins
+        TreatMissingData: "breaching",
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Duration",
+        Statistic: "Maximum",
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 1200, // 40% of default 3 second timeout
+        EvaluationPeriods: 4,
+        DatapointsToAlarm: 1,
+        Period: 300, // 5 mins
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: [
+          {
+            MetricStat: {
+              Stat: "Maximum",
+              Period: 300, // 5 mins
+              Metric: {
+                Namespace: "LambdaInsights",
+                MetricName: "memory_utilization",
+                Dimensions: [
+                  {
+                    Name: "function_name",
+                    Value: { Ref: Match.stringLikeRegexp("^MyFunction.*") },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        ComparisonOperator: "GreaterThanOrEqualToThreshold",
+        Threshold: 50,
+        EvaluationPeriods: 6,
+        DatapointsToAlarm: 2,
+        TreatMissingData: "notBreaching",
+      });
+    });
+  });
+
+  describe("alarm notifications", () => {
+    it("should configure notifications by default", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_135_0,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        AlarmActions: [
+          {
+            "Fn::Join": ["", Match.arrayWith([":sns:", ":exampleSnsTopic"])],
+          },
+        ],
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Duration",
+        AlarmActions: [
+          {
+            "Fn::Join": ["", Match.arrayWith([":sns:", ":exampleSnsTopic"])],
+          },
+        ],
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Throttles",
+        AlarmActions: [
+          {
+            "Fn::Join": ["", Match.arrayWith([":sns:", ":exampleSnsTopic"])],
+          },
+        ],
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: Match.arrayWith([
+          Match.objectLike({
+            MetricStat: {
+              Metric: {
+                Namespace: "LambdaInsights",
+                MetricName: "memory_utilization",
+              },
+            },
+          }),
+        ]),
+        AlarmActions: [
+          {
+            "Fn::Join": ["", Match.arrayWith([":sns:", ":exampleSnsTopic"])],
+          },
+        ],
+      });
+    });
+
+    it("should not configure notifications when 'alarmNotificationsTopic' is omitted in the context", () => {
+      const app = new cdk.App({
+        context: {
+          ENVIRONMENT: "prod",
+          CUSTOMER: "cuckoo",
+          cuckoo: {
+            // Deliberately omit alarmNotificationsTopic property
+            prod: {
+              logLevel: "debug",
+            },
+          },
+        },
+      });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_135_0,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Duration",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Throttles",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: Match.arrayWith([
+          Match.objectLike({
+            MetricStat: {
+              Metric: {
+                Namespace: "LambdaInsights",
+                MetricName: "memory_utilization",
+              },
+            },
+          }),
+        ]),
+        AlarmActions: Match.absent(),
+      });
+    });
+
+    it("should not configure notifications when 'disableAlarmNotifications' is true", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(
+            this,
+            "Function",
+            {
+              entry: path.join(__dirname, "test/mock-handler.ts"),
+              insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_135_0,
+            },
+            {
+              disableAlarmNotifications: true,
+            }
+          );
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Errors",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Duration",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        MetricName: "Throttles",
+        AlarmActions: Match.absent(),
+      });
+
+      template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+        Metrics: Match.arrayWith([
+          Match.objectLike({
+            MetricStat: {
+              Metric: {
+                Namespace: "LambdaInsights",
+                MetricName: "memory_utilization",
+              },
+            },
+          }),
+        ]),
+        AlarmActions: Match.absent(),
+      });
+    });
+  });
+
+  describe("tracing", () => {
+    it("should default to active x-ray tracing", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        TracingConfig: {
+          Mode: "Active",
+        },
+      });
+    });
+
+    it("should be overridable via props", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(this, "Function", {
+            entry: path.join(__dirname, "test/mock-handler.ts"),
+            tracing: lambda.Tracing.PASS_THROUGH,
+          });
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        TracingConfig: {
+          Mode: "PassThrough",
+        },
+      });
+    });
+  });
+
+  describe("policies", () => {
+    it("should add the SSM Get parameter policy if the SSM parameter path is passed", () => {
+      const app = new cdk.App({ context });
+
+      class UnitTestStack extends cdk.Stack {
+        constructor(scope: Construct) {
+          super(scope, UnitTestStack.name);
+
+          new NodejsFunction(
+            this,
+            "Function",
+            {
+              entry: path.join(__dirname, "test/mock-handler.ts"),
+            },
+            {
+              ssmParameterPaths: [
+                "example-path/for-ssm-parameter1",
+                "example-path/for-ssm-parameter2/*",
+              ],
+            }
+          );
+        }
+      }
+
+      const template = Template.fromStack(new UnitTestStack(app));
+
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            {
+              Action: [
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParametersByPath",
+              ],
+              Effect: "Allow",
+              Resource: [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        Ref: "AWS::Partition",
+                      },
+                      ":ssm:",
+                      {
+                        Ref: "AWS::Region",
+                      },
+                      ":",
+                      {
+                        Ref: "AWS::AccountId",
+                      },
+                      ":parameter/example-path/for-ssm-parameter1",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        Ref: "AWS::Partition",
+                      },
+                      ":ssm:",
+                      {
+                        Ref: "AWS::Region",
+                      },
+                      ":",
+                      {
+                        Ref: "AWS::AccountId",
+                      },
+                      ":parameter/example-path/for-ssm-parameter2/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ]),
+        },
+      });
+    });
+  });
+});

--- a/src/lambda/test/mock-handler.ts
+++ b/src/lambda/test/mock-handler.ts
@@ -1,0 +1,3 @@
+export const handler = () => {
+  console.log("Hello world handler!!");
+};


### PR DESCRIPTION
## Background
Adds in `lambda.NodejsFunction` construct so we can take advantage of the same great defaults supplied in `lambda.Function` but also use `esbuild`. This will result in reduced build and deployment times, as well as reducing the overall size of our Lambda functions which have Node.js as their runtime.

## Changes
- Adds in `lambda.NodejsFunction` construct.
- Create common alarm infra logic for Lambda constructs.

## Notes
If testing locally make sure to do an npm i to esbuild is installed locally and can be used by the construct. Not doing this will mean the Lambdas are built in a local docker container which is really slow.
