### PR TITLE
fix(alarm): Make lambda error alarm look at correct stat

### DIFF
--- a/src/lambda/common.ts
+++ b/src/lambda/common.ts
@@ -59,7 +59,7 @@ export const createAlarms = ({
 
   const errorsAlarm = lambdaFunction
     .metricErrors({
-      statistic: "Maximum",
+      statistic: "Sum",
     })
     .createAlarm(lambdaFunction, "Errors", {
       ...defaultErrorAlarmOptions,

--- a/src/lambda/function.test.ts
+++ b/src/lambda/function.test.ts
@@ -306,7 +306,7 @@ describe("function", () => {
 
       template.hasResourceProperties("AWS::CloudWatch::Alarm", {
         MetricName: "Errors",
-        Statistic: "Maximum",
+        Statistic: "Sum",
         ComparisonOperator: "GreaterThanOrEqualToThreshold",
         Threshold: 1,
         EvaluationPeriods: 1,
@@ -492,7 +492,7 @@ describe("function", () => {
 
       template.hasResourceProperties("AWS::CloudWatch::Alarm", {
         MetricName: "Errors",
-        Statistic: "Maximum",
+        Statistic: "Sum",
         ComparisonOperator: "GreaterThanOrEqualToThreshold",
         Threshold: 2,
         EvaluationPeriods: 5,

--- a/src/lambda/nodejs-function.test.ts
+++ b/src/lambda/nodejs-function.test.ts
@@ -294,7 +294,7 @@ describe("NodejsFunction", () => {
 
       template.hasResourceProperties("AWS::CloudWatch::Alarm", {
         MetricName: "Errors",
-        Statistic: "Maximum",
+        Statistic: "Sum",
         ComparisonOperator: "GreaterThanOrEqualToThreshold",
         Threshold: 1,
         EvaluationPeriods: 1,
@@ -475,7 +475,7 @@ describe("NodejsFunction", () => {
 
       template.hasResourceProperties("AWS::CloudWatch::Alarm", {
         MetricName: "Errors",
-        Statistic: "Maximum",
+        Statistic: "Sum",
         ComparisonOperator: "GreaterThanOrEqualToThreshold",
         Threshold: 2,
         EvaluationPeriods: 5,


### PR DESCRIPTION
__This fix was originally made in the private version of the library but never copied to this one__

## Background

The default errors alarm setup for lambdas was looking at the incorrect statistic - it was looking at the max of errors rather than the sum.

When you use max, you get the maximum of all metric values over that period. The value of every lambda error metric is 1, so if there are 1 or 100 error metrics reported to CloudWatch within a period you'll only ever see 1.

I think the intention here was to use sum.

## Changes

- Change lambda error alarm stat to sum
- Update tests
