### PR TITLE
chore(deps): GitHub actions updates

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         # These correlate to the latest two runtimes supported by Lambda
         # See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-        node: [ 16, 18 ]
+        node: [16, 18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -28,9 +28,9 @@ jobs:
       matrix:
         # These correlate to the latest two runtimes supported by Lambda
         # See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-        node: [ 16, 18 ]
+        node: [16, 18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,14 @@ name: Publish Package
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "18"

--- a/.github/workflows/version-changelog.yml
+++ b/.github/workflows/version-changelog.yml
@@ -9,8 +9,8 @@ jobs:
   version:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           release-type: node
-          package-name: "aws-constructs"
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,7 @@
+{
+  "packages": {
+    "./": {
+      "package-name": "aws-constructs"
+    }
+  }
+}


### PR DESCRIPTION
## Background

Actions that run on Node.js 16 are deprecated. This bumps checkout and release-please to versions that use Node.js 20.

release-please had some breaking changes in v4, so I've added in the required config file.

## Changes

- Update checkout action
- Update release please

