### PR TITLE
feat(function): Migrate logRetention usage to logGroup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,9 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.51.0",
-        "constructs": "^10.2.70"
+        "aws-cdk-lib": "^2.135.0",
+        "constructs": "^10.2.70",
+        "esbuild": "^0.19.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -57,9 +58,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==",
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
       "peer": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -2539,9 +2540,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.95.1.tgz",
-      "integrity": "sha512-FQlnW3+c1j2W7hmu+QMSiWnBgbW1Lhn1ZpBQ6cwYZa97rII1zlEyTowAfzQk6szPIzUhJv5xK03nWZtvCvpAWw==",
+      "version": "2.136.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.136.0.tgz",
+      "integrity": "sha512-zdkWNe91mvZH6ESghUoIxB8ORoreExg2wowTLEVfy3vWY1a6n69crxk8mkCG+vn6GhXEnEPpovoG1QV8BpXTpA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2552,22 +2553,24 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "peer": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -2694,7 +2697,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2714,7 +2717,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2776,6 +2779,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
       "inBundle": true,
@@ -2789,7 +2813,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2807,7 +2831,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.0",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -2865,7 +2889,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2881,7 +2905,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -5544,7 +5568,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -7388,7 +7411,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7397,7 +7419,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7968,7 +7989,6 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8394,7 +8414,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9865,9 +9884,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==",
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
       "peer": true
     },
     "@aws-cdk/asset-kubectl-v20": {
@@ -11606,23 +11625,24 @@
       "dev": true
     },
     "aws-cdk-lib": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.95.1.tgz",
-      "integrity": "sha512-FQlnW3+c1j2W7hmu+QMSiWnBgbW1Lhn1ZpBQ6cwYZa97rII1zlEyTowAfzQk6szPIzUhJv5xK03nWZtvCvpAWw==",
+      "version": "2.136.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.136.0.tgz",
+      "integrity": "sha512-zdkWNe91mvZH6ESghUoIxB8ORoreExg2wowTLEVfy3vWY1a6n69crxk8mkCG+vn6GhXEnEPpovoG1QV8BpXTpA==",
       "peer": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -11708,7 +11728,7 @@
           "peer": true
         },
         "fs-extra": {
-          "version": "11.1.1",
+          "version": "11.2.0",
           "bundled": true,
           "peer": true,
           "requires": {
@@ -11723,7 +11743,7 @@
           "peer": true
         },
         "ignore": {
-          "version": "5.2.4",
+          "version": "5.3.1",
           "bundled": true,
           "peer": true
         },
@@ -11764,6 +11784,19 @@
             "yallist": "^4.0.0"
           }
         },
+        "mime-db": {
+          "version": "1.52.0",
+          "bundled": true,
+          "peer": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        },
         "minimatch": {
           "version": "3.1.2",
           "bundled": true,
@@ -11773,7 +11806,7 @@
           }
         },
         "punycode": {
-          "version": "2.3.0",
+          "version": "2.3.1",
           "bundled": true,
           "peer": true
         },
@@ -11783,7 +11816,7 @@
           "peer": true
         },
         "semver": {
-          "version": "7.5.4",
+          "version": "7.6.0",
           "bundled": true,
           "peer": true,
           "requires": {
@@ -11819,7 +11852,7 @@
           }
         },
         "table": {
-          "version": "6.8.1",
+          "version": "6.8.2",
           "bundled": true,
           "peer": true,
           "requires": {
@@ -11831,7 +11864,7 @@
           }
         },
         "universalify": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "peer": true
         },
@@ -13630,8 +13663,7 @@
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -14883,12 +14915,10 @@
     },
     "mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "peer": true
     },
     "mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "peer": true,
       "requires": {
         "mime-db": "1.52.0"
@@ -15258,8 +15288,7 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "pure-rand": {
       "version": "6.0.3",
@@ -15538,8 +15567,7 @@
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
     },
     "serialize-javascript": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "get-value": "3.0.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.51.0",
+    "aws-cdk-lib": "^2.136.0",
     "constructs": "^10.2.70",
     "esbuild": "^0.19.3"
   },

--- a/src/lambda/function.test.ts
+++ b/src/lambda/function.test.ts
@@ -155,8 +155,8 @@ describe("function", () => {
     });
   });
 
-  describe("logRetention", () => {
-    it("should default to six months", () => {
+  describe("logs", () => {
+    it("should create a log group with 6 months of log retention", () => {
       const app = new cdk.App({ context });
 
       class UnitTestStack extends cdk.Stack {
@@ -171,12 +171,13 @@ describe("function", () => {
       }
       const template = Template.fromStack(new UnitTestStack(app));
 
-      template.hasResourceProperties("Custom::LogRetention", {
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 180,
+        LogGroupName: "/aws/lambda/FunctionLogGroup-prod",
       });
     });
 
-    it("should be overridable via props", () => {
+    it("should allow log retention to be overwritten", () => {
       const app = new cdk.App({ context });
 
       class UnitTestStack extends cdk.Stack {
@@ -190,11 +191,11 @@ describe("function", () => {
           });
         }
       }
-
       const template = Template.fromStack(new UnitTestStack(app));
 
-      template.hasResourceProperties("Custom::LogRetention", {
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 365,
+        LogGroupName: "/aws/lambda/FunctionLogGroup-prod",
       });
     });
   });

--- a/src/lambda/function.ts
+++ b/src/lambda/function.ts
@@ -60,17 +60,22 @@ export class Function extends lambda.Function {
       LOG_LEVEL: logLevel,
     };
 
+    const { logRetention, ...restProps } = props;
+
     const defaultFunctionProps: Partial<lambda.FunctionProps> = {
       architecture: lambda.Architecture.ARM_64,
       description: `${id}-${environment}`,
       runtime: lambda.Runtime.NODEJS_18_X,
-      logRetention: logs.RetentionDays.SIX_MONTHS,
       tracing: lambda.Tracing.ACTIVE,
+      logGroup: new logs.LogGroup(scope, `${id}LogGroup`, {
+        logGroupName: `/aws/lambda/${id}LogGroup-${environment}`,
+        retention: logRetention ?? logs.RetentionDays.SIX_MONTHS,
+      }),
     };
 
     const mergedProps: lambda.FunctionProps = {
       ...(defaultFunctionProps as lambda.FunctionProps),
-      ...props,
+      ...restProps,
       environment: {
         ...defaultEnvironment,
         ...props.environment,

--- a/src/lambda/nodejs-function.test.ts
+++ b/src/lambda/nodejs-function.test.ts
@@ -149,8 +149,8 @@ describe("NodejsFunction", () => {
     });
   });
 
-  describe("logRetention", () => {
-    it("should default to six months", () => {
+  describe("logs", () => {
+    it("should create a log group with 6 months of log retention", () => {
       const app = new cdk.App({ context });
 
       class UnitTestStack extends cdk.Stack {
@@ -164,12 +164,13 @@ describe("NodejsFunction", () => {
       }
       const template = Template.fromStack(new UnitTestStack(app));
 
-      template.hasResourceProperties("Custom::LogRetention", {
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 180,
+        LogGroupName: "/aws/lambda/FunctionLogGroup-prod",
       });
     });
 
-    it("should be overridable via props", () => {
+    it("should allow log retention to be overwritten", () => {
       const app = new cdk.App({ context });
 
       class UnitTestStack extends cdk.Stack {
@@ -182,11 +183,11 @@ describe("NodejsFunction", () => {
           });
         }
       }
-
       const template = Template.fromStack(new UnitTestStack(app));
 
-      template.hasResourceProperties("Custom::LogRetention", {
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 365,
+        LogGroupName: "/aws/lambda/FunctionLogGroup-prod",
       });
     });
   });

--- a/src/lambda/nodejs-function.ts
+++ b/src/lambda/nodejs-function.ts
@@ -74,17 +74,22 @@ export class NodejsFunction extends nodejs.NodejsFunction {
       LOG_LEVEL: logLevel,
     };
 
+    const { logRetention, ...restProps } = props;
+
     const defaultFunctionProps: Partial<nodejs.NodejsFunctionProps> = {
       architecture: lambda.Architecture.ARM_64,
       description: `${id}-${environment}`,
       runtime: lambda.Runtime.NODEJS_18_X,
-      logRetention: logs.RetentionDays.SIX_MONTHS,
       tracing: lambda.Tracing.ACTIVE,
+      logGroup: new logs.LogGroup(scope, `${id}LogGroup`, {
+        logGroupName: `/aws/lambda/${id}LogGroup-${environment}`,
+        retention: logRetention ?? logs.RetentionDays.SIX_MONTHS,
+      }),
     };
 
     const mergedProps: nodejs.NodejsFunctionProps = {
       ...(defaultFunctionProps as nodejs.NodejsFunctionProps),
-      ...props,
+      ...restProps,
       environment: {
         ...defaultEnvironment,
         ...props.environment,


### PR DESCRIPTION
## Background

This migrates the usage of the `logRetention` property to `logGroup` instead. `logGroup` was introduced in a more recent version of `aws-cdk-lib`.

`logRetention` works in an interesting way - it creates a custom resource under the hood (a Lambda) that when invoked creates a log group with the log retention property set to whatever value you pass in. I am not sure why it was originally implemented this way by the CDK team, but they have since introduced the `logGroup` API to allow a previously created log group to be passed in instead. 

The previous Lambda created by the custom resource approach was causing a few extra resources to be created that we didn't need, and was also causing some security alerts to be flagged by one of our monitoring platforms, as the created lambda did not have tracing enabled.

Once this is rolled out, all lambdas will start sending their logs to new log groups (`/aws/lambda/{id}LogGroup-${env}`) and the old log groups will stop receiving log streams. They will not be deleted however, as the default retention policy for log groups is `RETAIN`. 

## Changes

- Migrate usage of `logRetention` to `logGroup`
- Update unit tests
- Allow `logRetention` to still be present to overwrite `logGroup` retention period.

## Notes

[AWS CDK issue describing the deprecation](https://github.com/aws/aws-cdk/pull/28934/files). They actually reversed calling it a deprecation as its not available in _some_ regions, its just a recommendation now