### PR TITLE
feat: allow lambda functions to define node runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.135.0",
+        "aws-cdk-lib": "2.179.0",
         "constructs": "^10.2.70",
         "esbuild": "^0.19.3"
       }
@@ -58,22 +58,54 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
-      "peer": true
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.2.224",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.224.tgz",
+      "integrity": "sha512-4CQP+y0rLq4IWzOlTqBhe8IxBU3Tul9KcmHxiAqztQRWLIl5HAVGCOWdLzHMLgbpFWNNMlIJxB8GwBEV0pWtfQ==",
+      "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "license": "Apache-2.0",
       "peer": true
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "39.2.20",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
+      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -2540,9 +2572,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.136.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.136.0.tgz",
-      "integrity": "sha512-zdkWNe91mvZH6ESghUoIxB8ORoreExg2wowTLEVfy3vWY1a6n69crxk8mkCG+vn6GhXEnEPpovoG1QV8BpXTpA==",
+      "version": "2.179.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.179.0.tgz",
+      "integrity": "sha512-fwkoEzvh3TXYj+GPkyq/GSQt63JJV1dBgDKwr3xRdb8lQaPntSclmisa+ARO8tjPfkru1NqxAFQTtiqtAE83cA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2556,20 +2588,21 @@
         "yaml",
         "mime-types"
       ],
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.0",
+        "semver": "^7.6.3",
         "table": "^6.8.2",
         "yaml": "1.10.2"
       },
@@ -2587,15 +2620,15 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2696,8 +2729,24 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2717,7 +2766,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.1",
+      "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2753,7 +2802,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2766,18 +2815,6 @@
       "inBundle": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -2831,13 +2868,10 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.0",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2889,7 +2923,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2915,18 +2949,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/uri-js": {
       "version": "4.4.1",
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -7411,6 +7438,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7419,6 +7447,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7989,6 +8018,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9884,22 +9914,38 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
-      "peer": true
-    },
-    "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.2.224",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.224.tgz",
+      "integrity": "sha512-4CQP+y0rLq4IWzOlTqBhe8IxBU3Tul9KcmHxiAqztQRWLIl5HAVGCOWdLzHMLgbpFWNNMlIJxB8GwBEV0pWtfQ==",
       "peer": true
     },
     "@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "peer": true
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "39.2.20",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
+      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
+      "peer": true,
+      "requires": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "7.7.1",
+          "bundled": true,
+          "peer": true
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -11625,23 +11671,23 @@
       "dev": true
     },
     "aws-cdk-lib": {
-      "version": "2.136.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.136.0.tgz",
-      "integrity": "sha512-zdkWNe91mvZH6ESghUoIxB8ORoreExg2wowTLEVfy3vWY1a6n69crxk8mkCG+vn6GhXEnEPpovoG1QV8BpXTpA==",
+      "version": "2.179.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.179.0.tgz",
+      "integrity": "sha512-fwkoEzvh3TXYj+GPkyq/GSQt63JJV1dBgDKwr3xRdb8lQaPntSclmisa+ARO8tjPfkru1NqxAFQTtiqtAE83cA==",
       "peer": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.0",
+        "semver": "^7.6.3",
         "table": "^6.8.2",
         "yaml": "1.10.2"
       },
@@ -11652,14 +11698,14 @@
           "peer": true
         },
         "ajv": {
-          "version": "8.12.0",
+          "version": "8.17.1",
           "bundled": true,
           "peer": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
         },
         "ansi-regex": {
@@ -11727,8 +11773,13 @@
           "bundled": true,
           "peer": true
         },
+        "fast-uri": {
+          "version": "3.0.6",
+          "bundled": true,
+          "peer": true
+        },
         "fs-extra": {
-          "version": "11.2.0",
+          "version": "11.3.0",
           "bundled": true,
           "peer": true,
           "requires": {
@@ -11743,7 +11794,7 @@
           "peer": true
         },
         "ignore": {
-          "version": "5.3.1",
+          "version": "5.3.2",
           "bundled": true,
           "peer": true
         },
@@ -11767,7 +11818,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.1",
+          "version": "1.5.0",
           "bundled": true,
           "peer": true
         },
@@ -11775,14 +11826,6 @@
           "version": "4.4.2",
           "bundled": true,
           "peer": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "peer": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
         },
         "mime-db": {
           "version": "1.52.0",
@@ -11816,12 +11859,9 @@
           "peer": true
         },
         "semver": {
-          "version": "7.6.0",
+          "version": "7.6.3",
           "bundled": true,
-          "peer": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "peer": true
         },
         "slice-ansi": {
           "version": "4.0.0",
@@ -11852,7 +11892,7 @@
           }
         },
         "table": {
-          "version": "6.8.2",
+          "version": "6.9.0",
           "bundled": true,
           "peer": true,
           "requires": {
@@ -11870,16 +11910,10 @@
         },
         "uri-js": {
           "version": "4.4.1",
-          "bundled": true,
           "peer": true,
           "requires": {
             "punycode": "^2.1.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "peer": true
         },
         "yaml": {
           "version": "1.10.2",
@@ -14915,10 +14949,12 @@
     },
     "mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "peer": true
     },
     "mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "peer": true,
       "requires": {
         "mime-db": "1.52.0"
@@ -15288,7 +15324,8 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "pure-rand": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "get-value": "3.0.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.136.0",
+    "aws-cdk-lib": "2.179.0",
     "constructs": "^10.2.70",
     "esbuild": "^0.19.3"
   },

--- a/src/lambda/common.ts
+++ b/src/lambda/common.ts
@@ -17,6 +17,7 @@ export type CustomLambdaProps = {
   memoryUtilizationAlarmOptions?: CustomAlarmOptions;
   disableAlarmNotifications?: boolean;
   ssmParameterPaths?: string[];
+  runtime?: lambda.Runtime;
 };
 
 type AlarmOptions = {

--- a/src/lambda/function.test.ts
+++ b/src/lambda/function.test.ts
@@ -53,7 +53,7 @@ describe("function", () => {
             description: "unrelated",
             handler: "index.handler",
             code: lambda.Code.fromAsset(path.join(__dirname, ".")),
-            runtime: lambda.Runtime.NODEJS_12_X,
+            runtime: lambda.Runtime.NODEJS_18_X,
           });
         }
       }
@@ -98,7 +98,7 @@ describe("function", () => {
           new Function(this, "Function", {
             handler: "index.handler",
             code: lambda.Code.fromAsset(path.join(__dirname, ".")),
-            runtime: lambda.Runtime.NODEJS_12_X,
+            runtime: lambda.Runtime.NODEJS_18_X,
           });
         }
       }
@@ -106,7 +106,7 @@ describe("function", () => {
       const template = Template.fromStack(new UnitTestStack(app));
 
       template.hasResourceProperties("AWS::Lambda::Function", {
-        Runtime: "nodejs12.x",
+        Runtime: "nodejs18.x",
       });
     });
   });

--- a/src/lambda/function.ts
+++ b/src/lambda/function.ts
@@ -5,7 +5,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import type * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { getContextByPath } from "../utils/context-by-path";
-import { type CustomLambdaProps, createAlarms } from "./common";
+import { createAlarms, type CustomLambdaProps } from "./common";
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
@@ -65,7 +65,7 @@ export class Function extends lambda.Function {
     const defaultFunctionProps: Partial<lambda.FunctionProps> = {
       architecture: lambda.Architecture.ARM_64,
       description: `${id}-${environment}`,
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: customProps?.runtime ?? lambda.Runtime.NODEJS_18_X,
       tracing: lambda.Tracing.ACTIVE,
       logGroup: new logs.LogGroup(scope, `${id}LogGroup`, {
         logGroupName: `/aws/lambda/${id}LogGroup-${environment}`,
@@ -130,7 +130,6 @@ export class Function extends lambda.Function {
           )
         ),
       });
-
       this.addToRolePolicy(ssmPolicy);
     }
   }

--- a/src/lambda/nodejs-function.test.ts
+++ b/src/lambda/nodejs-function.test.ts
@@ -51,7 +51,7 @@ describe("NodejsFunction", () => {
           new NodejsFunction(this, "Function", {
             description: "unrelated",
             entry: path.join(__dirname, "test/mock-handler.ts"),
-            runtime: lambda.Runtime.NODEJS_12_X,
+            runtime: lambda.Runtime.NODEJS_18_X,
           });
         }
       }
@@ -94,7 +94,7 @@ describe("NodejsFunction", () => {
 
           new NodejsFunction(this, "Function", {
             entry: path.join(__dirname, "test/mock-handler.ts"),
-            runtime: lambda.Runtime.NODEJS_12_X,
+            runtime: lambda.Runtime.NODEJS_18_X,
           });
         }
       }
@@ -102,7 +102,7 @@ describe("NodejsFunction", () => {
       const template = Template.fromStack(new UnitTestStack(app));
 
       template.hasResourceProperties("AWS::Lambda::Function", {
-        Runtime: "nodejs12.x",
+        Runtime: "nodejs18.x",
       });
     });
   });

--- a/src/lambda/nodejs-function.ts
+++ b/src/lambda/nodejs-function.ts
@@ -6,22 +6,13 @@ import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import type * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { getContextByPath } from "../utils/context-by-path";
-import { createAlarms } from "./common";
+import { createAlarms, type CustomLambdaProps } from "./common";
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 type CustomAlarmOptions = Omit<
   cloudwatch.CreateAlarmOptions,
   "alarmDescription"
 >;
-
-type CustomLambdaProps = {
-  errorsAlarmOptions?: CustomAlarmOptions;
-  throttlesAlarmOptions?: CustomAlarmOptions;
-  durationAlarmOptions?: CustomAlarmOptions;
-  memoryUtilizationAlarmOptions?: CustomAlarmOptions;
-  disableAlarmNotifications?: boolean;
-  ssmParameterPaths?: string[];
-};
 
 /**
  * As well as the [usual defaults](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Function.html#construct-props), this construct will additionally configure the following for you:
@@ -79,7 +70,7 @@ export class NodejsFunction extends nodejs.NodejsFunction {
     const defaultFunctionProps: Partial<nodejs.NodejsFunctionProps> = {
       architecture: lambda.Architecture.ARM_64,
       description: `${id}-${environment}`,
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: customProps?.runtime ?? lambda.Runtime.NODEJS_18_X,
       tracing: lambda.Tracing.ACTIVE,
       logGroup: new logs.LogGroup(scope, `${id}LogGroup`, {
         logGroupName: `/aws/lambda/${id}LogGroup-${environment}`,
@@ -144,7 +135,6 @@ export class NodejsFunction extends nodejs.NodejsFunction {
           )
         ),
       });
-
       this.addToRolePolicy(ssmPolicy);
     }
   }

--- a/src/stepfunctions/state-machine.test.ts
+++ b/src/stepfunctions/state-machine.test.ts
@@ -29,7 +29,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -51,7 +51,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
             stateMachineType: sfn.StateMachineType.STANDARD,
           });
         }
@@ -76,7 +76,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -98,7 +98,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
             timeout: cdk.Duration.minutes(4),
           });
         }
@@ -123,7 +123,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -147,7 +147,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
             tracingEnabled: false,
           });
         }
@@ -156,7 +156,9 @@ describe("state machine", () => {
       const template = Template.fromStack(new UnitTestStack(app));
 
       template.hasResourceProperties("AWS::StepFunctions::StateMachine", {
-        TracingConfiguration: Match.absent(),
+        TracingConfiguration: {
+          Enabled: false,
+        },
       });
     });
   });
@@ -172,7 +174,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -201,7 +203,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -235,7 +237,7 @@ describe("state machine", () => {
             this,
             "StateMachine",
             {
-              definition,
+              definitionBody: sfn.DefinitionBody.fromChainable(definition),
             },
             {
               failedExecutionsAlarmOptions: {
@@ -293,7 +295,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -342,7 +344,7 @@ describe("state machine", () => {
           const definition = new sfn.Pass(this, "InitialPass");
 
           new StateMachine(this, "StateMachine", {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
           });
         }
       }
@@ -375,7 +377,7 @@ describe("state machine", () => {
             this,
             "StateMachine",
             {
-              definition,
+              definitionBody: sfn.DefinitionBody.fromChainable(definition),
             },
             {
               disableAlarmNotifications: true,


### PR DESCRIPTION
## Background
On going migration work.

## Changes
- Bumps cdk-lib version to support node22 runtimes
- Added optional prop member to allow implementations to define their own runtime
- Fixed tests 
